### PR TITLE
Add automatic script injection for advertiser pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,12 @@
   "permissions": ["scripting", "activeTab"],
   "host_permissions": ["https://adstransparency.google.com/*"],
   "background": { "service_worker": "background.js" },
-  "action": { "default_title": "Analisar Países" }
+  "action": { "default_title": "Analisar Países" },
+  "content_scripts": [
+    {
+      "matches": ["https://adstransparency.google.com/advertiser/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add `content_scripts` entry in `manifest.json` to automatically run the analyzer on `adstransparency.google.com/advertiser/*`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68405a8543208326a6153f6706dabe82